### PR TITLE
Modified fire-cat, gige-cat to use consistent args

### DIFF
--- a/sensors/dc1394/applications/fire-cat.cpp
+++ b/sensors/dc1394/applications/fire-cat.cpp
@@ -85,7 +85,7 @@ int main( int argc, char** argv )
             ( "long-help", "display long help message" )
             ( "list", "list cameras on the bus with guids" )
             ( "discard,d", "discard frames, if cannot keep up; same as --buffer=1" )
-            ( "config,c", boost::program_options::value< std::string >( &config_string )->default_value( "fire-cat.ini" ), "configuration file for the camera or comma-separated name=value string, see long help for details" )
+            ( "config,c", boost::program_options::value< std::string >( &config_string )->default_value( "fire-cat.ini" ), "configuration file for the camera or semicolon-separated name=value string, see long help for details" )
             ( "buffer", boost::program_options::value< unsigned int >( &discard )->default_value( 0 ), "maximum buffer size before discarding frames, default: unlimited" )
             ( "fields,f", boost::program_options::value< std::string >( &fields )->default_value( "t,rows,cols,type" ), "header fields, possible values: t,rows,cols,type,size" )
             ( "header", "output header only" )
@@ -209,7 +209,7 @@ int main( int argc, char** argv )
         }
         else
         {
-            comma::name_value::parser parser( ',', '=' );
+            comma::name_value::parser parser( ';', '=' );
             config = parser.get< snark::camera::dc1394::config >( config_string );
         }
         snark::camera::dc1394 camera( config, format7_width, format7_height, format7_size, exposure );

--- a/sensors/gige/applications/gige-cat.cpp
+++ b/sensors/gige/applications/gige-cat.cpp
@@ -39,7 +39,7 @@ int main( int argc, char** argv )
         boost::program_options::options_description description( "options" );
         description.add_options()
             ( "help,h", "display help message" )
-            ( "set", boost::program_options::value< std::string >( &setattributes ), "set camera attributes as comma-separated name-value pairs" )
+            ( "set", boost::program_options::value< std::string >( &setattributes ), "set camera attributes as semicolon-separated name-value pairs" )
             ( "set-and-exit", "set camera attributes specified in --set and exit" )
             ( "id", boost::program_options::value< unsigned int >( &id )->default_value( 0 ), "camera id; default: first available camera" )
             ( "discard", "discard frames, if cannot keep up; same as --buffer=1" )
@@ -86,7 +86,7 @@ int main( int argc, char** argv )
         snark::camera::gige::attributes_type attributes;
         if( vm.count( "set" ) )
         {
-            comma::name_value::map m( setattributes, ',', '=' );
+            comma::name_value::map m( setattributes, ';', '=' );
             attributes.insert( m.get().begin(), m.get().end() );
         }
         if( verbose ) { std::cerr << "gige-cat: connecting..." << std::endl; }


### PR DESCRIPTION
In most comma/snark programs, command line arguments are separated by 
semicolons. e.g.

```
cv-cat --input="rows=500;cols=1000;no-header;type=3ub"
```

But fire-cat and gige-cat required parameters in the form

```
fire-cat --config="output-type=RGB,guid=12345"
```

To make these apps consistent with the rest of comma and snark, the
"--config" and "--set" arguments of fire-cat and gige-cat respectively have
been changed to expect semicolon-separated name-value pairs.
