### PR TITLE
Updates for Ubuntu 22.04

### DIFF
--- a/actuators/quickset/ptcr/protocol.cpp
+++ b/actuators/quickset/ptcr/protocol.cpp
@@ -33,7 +33,7 @@
 #include <boost/asio/io_service.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/serial_port.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/optional.hpp>
 #include <boost/scoped_ptr.hpp>
 #include <boost/static_assert.hpp>

--- a/batteries/ocean/serial_io.cpp
+++ b/batteries/ocean/serial_io.cpp
@@ -21,7 +21,7 @@
 #include <string>
 #include <algorithm>
 #include <iostream>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <comma/base/exception.h>
 
 using namespace std;

--- a/batteries/ocean/stdio_query.cpp
+++ b/batteries/ocean/stdio_query.cpp
@@ -103,7 +103,7 @@ void stdio_query::async_receive(const boost::asio::mutable_buffer& buffer, boost
     received_length_ = 0;
     
     input_.async_read_some(boost::asio::buffer(buffer),
-                          boost::bind(&stdio_query::handle_receive, _1, _2, &error_code_, &received_length_));
+                          boost::bind(&stdio_query::handle_receive, boost::placeholders::_1, _2, &error_code_, &received_length_));
 }
 
 
@@ -118,10 +118,10 @@ std::size_t stdio_query::receive(const boost::asio::mutable_buffer& buffer,
     std::size_t length = 0;
     
     input_.async_read_some(boost::asio::buffer(buffer),
-                          boost::bind(&stdio_query::handle_receive, _1, _2, &ec, &length));
+                          boost::bind(&stdio_query::handle_receive, boost::placeholders::_1, _2, &ec, &length));
     // boost::asio::async_read( input_, boost::asio::buffer(buffer),
     //                         boost::asio::transfer_at_least(1),
-    //                         boost::bind(&stdio_query::handle_receive, _1, _2, &ec, &length));
+    //                         boost::bind(&stdio_query::handle_receive, boost::placeholders::_1, _2, &ec, &length));
     
     // Block until the asynchronous operation has completed.
     do io_service_.run_one(); while (ec == boost::asio::error::would_block);

--- a/batteries/ocean/stdio_query.h
+++ b/batteries/ocean/stdio_query.h
@@ -37,7 +37,7 @@
 #include <iostream>
 #include <boost/asio.hpp>
 #include <boost/date_time/posix_time/posix_time_types.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/asio/deadline_timer.hpp>
 #include <boost/asio/posix/stream_descriptor.hpp>
 #include <comma/base/types.h>

--- a/dependencies.commits
+++ b/dependencies.commits
@@ -1,1 +1,1 @@
-comma,8b6ae0214296a6bf4eafd52ac5dcf18192f80849
+comma,dbfeb541ad19c00c46cbae9c7d43b44dbd27c90b

--- a/graphics/applications/csv_plot/stream.cpp
+++ b/graphics/applications/csv_plot/stream.cpp
@@ -29,7 +29,7 @@
 
 /// @author Vsevolod Vlaskine
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include "stream.h"
 #include "traits.h"
 

--- a/graphics/applications/label_points/MainWindow.cpp
+++ b/graphics/applications/label_points/MainWindow.cpp
@@ -31,7 +31,7 @@
 #include <limits>
 #include <map>
 #ifndef Q_MOC_RUN
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/filesystem/path.hpp>
 #include <boost/lexical_cast.hpp>
 #endif
@@ -63,12 +63,12 @@ MainWindow::MainWindow( const std::string& title, Viewer* viewer )
     Actions::Action* saveAsAction = new Actions::Action( "SaveAs...", boost::bind( &MainWindow::saveAs, this ) );
     Actions::Action* reloadAction = new Actions::Action( "Reload", boost::bind( &Viewer::reload, viewer ) );
 
-    Actions::ToggleAction* navigateSceneAction = new Actions::ToggleAction( QIcon::fromTheme("edit-select", Icons::pointer() ) , "navigate scene", boost::bind( &Tools::Navigate::toggle, boost::ref( viewer->navigate ), _1 ), "Ctrl+Q" );
-    Actions::ToggleAction* selectPointsAction = new Actions::ToggleAction( QIcon::fromTheme("zoom-select", Icons::select()), "select points", boost::bind( &Tools::SelectClip::toggle, boost::ref( viewer->selectClip ), _1 ), "Ctrl+W" );
-    Actions::ToggleAction* selectPartitionAction = new Actions::ToggleAction( QIcon::fromTheme("tools-wizard", Icons::fuzzy()), "select partition", boost::bind( &Tools::SelectPartition::toggle, boost::ref( viewer->selectPartition ), _1 ), "Ctrl+E" );
-    Actions::ToggleAction* selectIdAction = new Actions::ToggleAction( QIcon::fromTheme("tools-wizard", Icons::fuzzy()), "select id", boost::bind( &Tools::SelectPartition::toggle, boost::ref( viewer->selectId ), _1 ), "Ctrl+R" );
-    Actions::ToggleAction* pipetteAction = new Actions::ToggleAction( QIcon::fromTheme("color-picker", Icons::pipette()), "pick id", boost::bind( &Tools::PickId::toggle, boost::ref( viewer->pickId ), _1 ), "Ctrl+T" );
-    Actions::ToggleAction* bucketAction = new Actions::ToggleAction( QIcon::fromTheme("fill-color", Icons::bucket()), "set id", boost::bind( &Tools::Fill::toggle, boost::ref( viewer->fill ), _1 ), "Ctrl+Y" );
+    Actions::ToggleAction* navigateSceneAction = new Actions::ToggleAction( QIcon::fromTheme("edit-select", Icons::pointer() ) , "navigate scene", boost::bind( &Tools::Navigate::toggle, boost::ref( viewer->navigate ), boost::placeholders::_1 ), "Ctrl+Q" );
+    Actions::ToggleAction* selectPointsAction = new Actions::ToggleAction( QIcon::fromTheme("zoom-select", Icons::select()), "select points", boost::bind( &Tools::SelectClip::toggle, boost::ref( viewer->selectClip ), boost::placeholders::_1 ), "Ctrl+W" );
+    Actions::ToggleAction* selectPartitionAction = new Actions::ToggleAction( QIcon::fromTheme("tools-wizard", Icons::fuzzy()), "select partition", boost::bind( &Tools::SelectPartition::toggle, boost::ref( viewer->selectPartition ), boost::placeholders::_1 ), "Ctrl+E" );
+    Actions::ToggleAction* selectIdAction = new Actions::ToggleAction( QIcon::fromTheme("tools-wizard", Icons::fuzzy()), "select id", boost::bind( &Tools::SelectPartition::toggle, boost::ref( viewer->selectId ), boost::placeholders::_1 ), "Ctrl+R" );
+    Actions::ToggleAction* pipetteAction = new Actions::ToggleAction( QIcon::fromTheme("color-picker", Icons::pipette()), "pick id", boost::bind( &Tools::PickId::toggle, boost::ref( viewer->pickId ), boost::placeholders::_1 ), "Ctrl+T" );
+    Actions::ToggleAction* bucketAction = new Actions::ToggleAction( QIcon::fromTheme("fill-color", Icons::bucket()), "set id", boost::bind( &Tools::Fill::toggle, boost::ref( viewer->fill ), boost::placeholders::_1 ), "Ctrl+Y" );
 
     selectPointsAction->setToolTip( "select points, click and drag<br>"
                                     "hold Ctrl to add to current selection<br>"
@@ -139,7 +139,7 @@ MainWindow::MainWindow( const std::string& title, Viewer* viewer )
     resize( 640, 480 );
 
     m_viewMenu = menuBar()->addMenu( "View" );
-    Actions::ToggleAction* action = new Actions::ToggleAction( "File Panel", boost::bind( &MainWindow::toggleFileFrame, this, _1 ) );
+    Actions::ToggleAction* action = new Actions::ToggleAction( "File Panel", boost::bind( &MainWindow::toggleFileFrame, this, boost::placeholders::_1 ) );
     action->setChecked( m_fileFrameVisible );
     m_viewMenu->addAction( action );
     connect( viewer, SIGNAL( initialized() ), this, SLOT( viewerInitialized() ) );
@@ -256,11 +256,11 @@ void MainWindow::updateFileFrame()
         }
         if( !sameFields ) { filename += ": \"" + m_viewer.datasets()[i]->options().fields + "\""; }
         m_fileLayout->addWidget( new QLabel( filename.c_str() ), i + 1, 0, Qt::AlignLeft | Qt::AlignTop );
-        CheckBox* viewBox = new CheckBox( boost::bind( &Viewer::show, boost::ref( m_viewer ), i, _1 ) );
+        CheckBox* viewBox = new CheckBox( boost::bind( &Viewer::show, boost::ref( m_viewer ), i, boost::placeholders::_1 ) );
         viewBox->setCheckState( Qt::Checked );
         viewBox->setToolTip( ( std::string( "check to make " ) + filename + " visible" ).c_str() );
         m_fileLayout->addWidget( viewBox, i + 1, 1, Qt::AlignRight | Qt::AlignTop );
-        CheckBox* writeBox = new CheckBox( boost::bind( &Viewer::setWritable, boost::ref( m_viewer ), i, _1 ) );
+        CheckBox* writeBox = new CheckBox( boost::bind( &Viewer::setWritable, boost::ref( m_viewer ), i, boost::placeholders::_1 ) );
         writeBox->setToolTip( ( std::string( "check to make " ) + filename + " writable" ).c_str() );
         if( i == 0 ) { writeBox->setCheckState( Qt::Checked ); }
         m_fileLayout->addWidget( writeBox, i + 1, 2, Qt::AlignRight | Qt::AlignTop );
@@ -273,10 +273,10 @@ void MainWindow::updateFileFrame()
     for( FileGroupMap::const_iterator it = m_fileGroups.begin(); it != m_fileGroups.end(); ++it, ++i )
     {
         m_fileLayout->addWidget( new QLabel( ( "\"" + it->first + "\"" ).c_str() ), i, 0, Qt::AlignLeft | Qt::AlignTop );
-        CheckBox* viewBox = new CheckBox( boost::bind( &MainWindow::showFileGroup, this, it->first, _1 ) );
+        CheckBox* viewBox = new CheckBox( boost::bind( &MainWindow::showFileGroup, this, it->first, boost::placeholders::_1 ) );
         viewBox->setToolTip( ( std::string( "check to make files with fields \"" ) + it->first + "\" visible" ).c_str() );
         m_fileLayout->addWidget( viewBox, i, 1, Qt::AlignRight | Qt::AlignTop );
-        CheckBox* writeBox = new CheckBox( boost::bind( &MainWindow::setWritableFileGroup, this, it->first, _1 ) );
+        CheckBox* writeBox = new CheckBox( boost::bind( &MainWindow::setWritableFileGroup, this, it->first, boost::placeholders::_1 ) );
         writeBox->setToolTip( ( std::string( "check to make files with fields \"" ) + it->first + "\" writable" ).c_str() );
         m_fileLayout->addWidget( writeBox, i, 2, Qt::AlignRight | Qt::AlignTop );
         m_fileLayout->setRowStretch( i, i + 1 == m_viewer.datasets().size() + fields.size() ? 1 : 0 );

--- a/graphics/applications/view_points/main_window.cpp
+++ b/graphics/applications/view_points/main_window.cpp
@@ -96,7 +96,7 @@ MainWindow::MainWindow( const std::string& title, const std::shared_ptr<snark::g
     resize( 640, 480 );
 
     m_viewMenu = menuBar()->addMenu( "View" );
-    ToggleAction* action = new ToggleAction( "File Panel", boost::bind( &MainWindow::toggleFileFrame, this, _1 ) );
+    ToggleAction* action = new ToggleAction( "File Panel", boost::bind( &MainWindow::toggleFileFrame, this, boost::placeholders::_1 ) );
     action->setChecked( m_fileFrameVisible );
     m_viewMenu->addAction( action );
     updateFileFrame();
@@ -158,7 +158,7 @@ void MainWindow::updateFileFrame() // quick and dirty
         }
         if( !sameFields ) { title += ": \"" + controller->readers[i]->options.fields + "\""; }
         m_fileLayout->addWidget( new QLabel( title.c_str() ), i + 1, 0, Qt::AlignLeft | Qt::AlignTop );
-        CheckBox* viewBox = new CheckBox( boost::bind( &Reader::show, boost::ref( *controller->readers[i] ), _1 ) );
+        CheckBox* viewBox = new CheckBox( boost::bind( &Reader::show, boost::ref( *controller->readers[i] ), boost::placeholders::_1 ) );
         viewBox->setCheckState( controller->readers[i]->show() ? Qt::Checked : Qt::Unchecked );
         connect( viewBox, SIGNAL( toggled( bool ) ), this, SLOT( update_view() ) ); // redraw when box is toggled
         viewBox->setToolTip( ( std::string( "check to make " ) + title + " visible" ).c_str() );
@@ -176,7 +176,7 @@ void MainWindow::updateFileFrame() // quick and dirty
     for( FileGroupMap::const_iterator it = m_userGroups.begin(); it != m_userGroups.end(); ++it, ++i )
     {
         m_fileLayout->addWidget( new QLabel( ( "\"" + it->first + "\"" ).c_str() ), i, 0, Qt::AlignLeft | Qt::AlignTop );
-        CheckBox* viewBox = new CheckBox( boost::bind( &MainWindow::showFileGroup, this, it->first, _1 ) );
+        CheckBox* viewBox = new CheckBox( boost::bind( &MainWindow::showFileGroup, this, it->first, boost::placeholders::_1 ) );
         //viewBox->setCheckState( Qt::Checked );
         viewBox->setToolTip( ( std::string( "check to make files within group \"" ) + it->first + "\" visible" ).c_str() );
         m_fileLayout->addWidget( viewBox, i, 1, Qt::AlignRight | Qt::AlignTop );
@@ -186,7 +186,7 @@ void MainWindow::updateFileFrame() // quick and dirty
     for( FileGroupMap::const_iterator it = m_fieldsGroups.begin(); it != m_fieldsGroups.end(); ++it, ++i )
     {
         m_fileLayout->addWidget( new QLabel( ( "\"" + it->first + "\"" ).c_str() ), i, 0, Qt::AlignLeft | Qt::AlignTop );
-        CheckBox* viewBox = new CheckBox( boost::bind( &MainWindow::showFileGroup, this, it->first, _1 ) );
+        CheckBox* viewBox = new CheckBox( boost::bind( &MainWindow::showFileGroup, this, it->first, boost::placeholders::_1 ) );
         //viewBox->setCheckState( Qt::Checked );
         viewBox->setToolTip( ( std::string( "check to make files with fields \"" ) + it->first + "\" visible" ).c_str() );
         m_fileLayout->addWidget( viewBox, i, 1, Qt::AlignRight | Qt::AlignTop );

--- a/imaging/applications/cv-calc.cpp
+++ b/imaging/applications/cv-calc.cpp
@@ -610,8 +610,8 @@ public:
         bool draw( cv::Mat m ) const
         {
             if( max.x == 0 && min.x == 0 && max.y == 0 && max.y == 0 ) { return false; }
-            if( properties.normalized ) { cv::rectangle( m, cv::Point2i( min.x * m.cols, min.y * m.rows ), cv::Point2i( max.x * m.cols, max.y * m.rows ), properties.color, properties.weight ); } // CV_AA );
-            else { cv::rectangle( m, min, max, properties.color, properties.weight ); } // CV_AA );
+            if( properties.normalized ) { cv::rectangle( m, cv::Point2i( min.x * m.cols, min.y * m.rows ), cv::Point2i( max.x * m.cols, max.y * m.rows ), properties.color, properties.weight ); } // cv::LINE_AA );
+            else { cv::rectangle( m, min, max, properties.color, properties.weight ); } // cv::LINE_AA );
             return true;
         }
     };
@@ -624,8 +624,8 @@ public:
         bool draw( cv::Mat m ) const
         {
             if( !comma::math::less( 0, radius ) ) { return false; }
-            if( properties.normalized ) { cv::circle( m, cv::Point2i( centre.x * m.cols, centre.y * m.rows ), radius * m.cols, properties.color, properties.weight, CV_AA ); }
-            else { cv::circle( m, centre, radius, properties.color, properties.weight, CV_AA ); }
+            if( properties.normalized ) { cv::circle( m, cv::Point2i( centre.x * m.cols, centre.y * m.rows ), radius * m.cols, properties.color, properties.weight, cv::LINE_AA ); }
+            else { cv::circle( m, centre, radius, properties.color, properties.weight, cv::LINE_AA ); }
             return true;
         }
     };
@@ -638,7 +638,7 @@ public:
         bool draw( cv::Mat m ) const
         {
             if( text.empty() ) { return false; }
-            cv::putText( m, text, properties.normalized ? cv::Point2f( position.x * m.cols, position.y * m.rows ) : position, cv::FONT_HERSHEY_SIMPLEX, 1.0, properties.color, properties.weight, CV_AA );
+            cv::putText( m, text, properties.normalized ? cv::Point2f( position.x * m.cols, position.y * m.rows ) : position, cv::FONT_HERSHEY_SIMPLEX, 1.0, properties.color, properties.weight, cv::LINE_AA );
             return true;
         }
     };

--- a/imaging/applications/cv-cat.cpp
+++ b/imaging/applications/cv-cat.cpp
@@ -316,7 +316,7 @@ int main( int argc, char** argv )
             reader.reset( new bursty_reader< pair >( boost::bind( &read, boost::ref( input ), boost::ref( rate ) ), discard, capacity ) );
         }
         const unsigned int default_delay = vm.count( "file" ) == 0 ? 1 : 200; // HACK to make view work on single files
-        pipeline_with_header pipeline( output, filters_with_header::make( filters, boost::bind( &get_timestamp_from_header, _1, input.header_binary() ), default_delay ), *reader, number_of_threads );
+        pipeline_with_header pipeline( output, filters_with_header::make( filters, boost::bind( &get_timestamp_from_header, boost::placeholders::_1, input.header_binary() ), default_delay ), *reader, number_of_threads );
         pipeline.run();
         if( vm.count( "stay" ) ) { while( !is_shutdown ) { boost::this_thread::sleep( boost::posix_time::seconds( 1 ) ); } }
         return 0;

--- a/imaging/applications/image-accumulate.cpp
+++ b/imaging/applications/image-accumulate.cpp
@@ -36,7 +36,7 @@
 #include <limits>
 #include <map>
 #include <boost/array.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/date_time/posix_time/ptime.hpp>
 #include <boost/function.hpp>
 #include <boost/optional.hpp>
@@ -350,7 +350,7 @@ static void output_once_( const boost::posix_time::ptime& t )
 
 static void output_()
 {
-    static const boost::posix_time::time_duration period = boost::posix_time::milliseconds( 1000.0 / *fps );
+    static const boost::posix_time::time_duration period = boost::posix_time::milliseconds( (long) ( 1000.0 / *fps ) );
     static const boost::posix_time::time_duration timeout = boost::posix_time::milliseconds( 10 );
     boost::posix_time::ptime time_to_output = boost::posix_time::microsec_clock::universal_time() + period;    
     while( !is_shutdown && !done && std::cout.good() )

--- a/imaging/applications/image-pinhole-calibrate.cpp
+++ b/imaging/applications/image-pinhole-calibrate.cpp
@@ -175,7 +175,7 @@ static double reprojection_error( const std::vector< std::vector< cv::Point3f > 
     for( unsigned int i = 0; i < object_points.size(); ++i )
     {
         cv::projectPoints( cv::Mat( object_points[i] ), rvecs[i], tvecs[i], camera_matrix, distortion_coefficients, image_points_2 );
-        double err = cv::norm( cv::Mat( image_points[i] ), cv::Mat( image_points_2 ), CV_L2 );
+        double err = cv::norm( cv::Mat( image_points[i] ), cv::Mat( image_points_2 ), cv::NORM_L2 );
         unsigned int n = object_points[i].size();
         per_view_errors[i] = std::sqrt( err * err / n );
         total_error += err * err;
@@ -196,7 +196,7 @@ static bool calibrate( const std::vector< cv::Point3f >& pattern_corners
 {
     std::vector< float > reprojection_errors;
     std::vector< std::vector< cv::Point3f > > object_points( image_points.size(), pattern_corners );
-    cv::calibrateCamera( object_points, image_points, image_size, camera_matrix, distortion_coefficients, rvecs, tvecs, flags | CV_CALIB_FIX_K4 | CV_CALIB_FIX_K5 );
+    cv::calibrateCamera( object_points, image_points, image_size, camera_matrix, distortion_coefficients, rvecs, tvecs, flags | cv::CALIB_FIX_K4 | cv::CALIB_FIX_K5 );
     bool ok = cv::checkRange( camera_matrix ) && cv::checkRange( distortion_coefficients );
     total_average_error = reprojection_error( object_points, image_points, rvecs, tvecs, camera_matrix, distortion_coefficients, reprojection_errors );
     return ok;
@@ -284,9 +284,9 @@ int main( int ac, char** av )
         if( pattern == patterns::invalid ) { std::cerr << "image-pinhole-calibration: expected calibration pattern, got: \"" << pattern_string << "\"" << std::endl; }
         float square_size = options.value< float >( "--pattern-square-size,--square-size", 1 ); 
         int flags = 0;
-        if( options.exists( "--no-principal-point" ) ) { flags |= CV_CALIB_FIX_PRINCIPAL_POINT; }
-        if( options.exists( "--no-tangential-distortion" ) ) { flags |= CV_CALIB_ZERO_TANGENT_DIST; }
-        if( options.exists( "--no-aspect-ratio" ) ) { flags |= CV_CALIB_FIX_ASPECT_RATIO; }
+        if( options.exists( "--no-principal-point" ) ) { flags |= cv::CALIB_FIX_PRINCIPAL_POINT; }
+        if( options.exists( "--no-tangential-distortion" ) ) { flags |= cv::CALIB_ZERO_TANGENT_DIST; }
+        if( options.exists( "--no-aspect-ratio" ) ) { flags |= cv::CALIB_FIX_ASPECT_RATIO; }
         bool view = options.exists( "--view" );
         bool verbose = options.exists( "--verbose,-v" );
         std::vector< std::vector< cv::Point2f > > image_points;
@@ -307,7 +307,7 @@ int main( int ac, char** av )
             //if( view ) { images.push_back( pair.second.clone() ); }
             image_size = pair.second.size();
             std::vector< cv::Point2f > points;
-            bool found = pattern == patterns::chessboard ? cv::findChessboardCorners( pair.second, pattern_size, points, CV_CALIB_CB_ADAPTIVE_THRESH | CV_CALIB_CB_FAST_CHECK | CV_CALIB_CB_NORMALIZE_IMAGE )
+            bool found = pattern == patterns::chessboard ? cv::findChessboardCorners( pair.second, pattern_size, points, cv::CALIB_CB_ADAPTIVE_THRESH | cv::CALIB_CB_FAST_CHECK | cv::CALIB_CB_NORMALIZE_IMAGE )
                        : pattern == patterns::circles_grid ? findCirclesGrid( view, pattern_size, points )
                        : pattern == patterns::asymmetric_circles_grid ? findCirclesGrid( view, pattern_size, points, cv::CALIB_CB_ASYMMETRIC_GRID )
                        : false;
@@ -324,7 +324,7 @@ int main( int ac, char** av )
             {
                 cv::Mat grey;
                 cv::cvtColor( pair.second, grey, cv::COLOR_BGR2GRAY );
-                cv::cornerSubPix( grey, points, cv::Size( 11, 11 ), cv::Size( -1, -1 ), cv::TermCriteria( CV_TERMCRIT_EPS + CV_TERMCRIT_ITER, 30, 0.1 ) );
+                cv::cornerSubPix( grey, points, cv::Size( 11, 11 ), cv::Size( -1, -1 ), cv::TermCriteria( cv::TermCriteria::MAX_ITER + cv::TermCriteria::EPS, 30, 0.1 ) );
             }
             image_points.push_back( points );
             timestamps.push_back( pair.first );
@@ -368,7 +368,7 @@ int main( int ac, char** av )
         else 
         {
             // set flag to use values from config
-            if (options.exists("--config")) { flags |= CV_CALIB_USE_INTRINSIC_GUESS; }
+            if (options.exists("--config")) { flags |= cv::CALIB_USE_INTRINSIC_GUESS; }
             if( !calibrate( pattern_corners, *image_size, image_points, flags, camera_matrix, distortion_coefficients, rvecs, tvecs, output.total_average_error ) ) { std::cerr << "image-pinhole-calibrate: calibration failed" << std::endl; return 1; }
         }
         for( unsigned int i = 0; i < images.size(); ++i )
@@ -381,7 +381,7 @@ int main( int ac, char** av )
         if( verbose ) { std::cerr << "image-pinhole-calibrate: outputting..." << std::endl; }
         output.pinhole.image_size = Eigen::Vector2i( image_size->width, image_size->height );
         output.pinhole.principal_point = Eigen::Vector2d( camera_matrix.at< double >( 0, 2 ), camera_matrix.at< double >( 1, 2 ) );
-        if( flags & CV_CALIB_FIX_ASPECT_RATIO )
+        if( flags & cv::CALIB_FIX_ASPECT_RATIO )
         {
             output.pinhole.focal_length = camera_matrix.at< double >( 0, 0 );
         }

--- a/imaging/camera/pinhole.cpp
+++ b/imaging/camera/pinhole.cpp
@@ -30,8 +30,9 @@
 #include <fstream>
 #include <iostream>
 #include <sstream>
-#include <boost/bind.hpp>
-#include <opencv2/imgproc/imgproc.hpp>
+#include <boost/bind/bind.hpp>
+#include <opencv2/imgproc.hpp>
+#include <opencv2/calib3d.hpp>
 #include <comma/application/verbose.h>
 #include <comma/base/exception.h>
 #include <comma/base/types.h>

--- a/imaging/cv_mat/bursty_pipeline.h
+++ b/imaging/cv_mat/bursty_pipeline.h
@@ -29,8 +29,8 @@
 
 #pragma once
 
-#include <tbb/pipeline.h>
-#include <tbb/task_scheduler_init.h>
+#include <tbb/parallel_pipeline.h>
+#include <tbb/task_arena.h>
 #include "../../tbb/bursty_reader.h"
 
 namespace snark { namespace tbb {
@@ -45,7 +45,7 @@ public:
     /// @param number_of_threads maximum number of threads, 0 means auto
     bursty_pipeline( unsigned int number_of_threads = 0 );
     
-    void run( bursty_reader< T >& reader, const ::tbb::filter_t< T, void >& filter );
+    void run( bursty_reader< T >& reader, const ::tbb::filter< T, void >& filter );
 
 private:
     unsigned int number_of_threads_;
@@ -53,10 +53,10 @@ private:
 
 
 template< typename T >
-inline bursty_pipeline< T >::bursty_pipeline( unsigned int number_of_threads ) : number_of_threads_( number_of_threads > 0 ? number_of_threads : ::tbb::task_scheduler_init::default_num_threads() ) {}
+inline bursty_pipeline< T >::bursty_pipeline( unsigned int number_of_threads ) : number_of_threads_( number_of_threads > 0 ? number_of_threads : ::tbb::this_task_arena::max_concurrency() ) {}
 
 template< typename T >
-inline void bursty_pipeline< T >::run( bursty_reader< T >& reader, const ::tbb::filter_t< T, void >& filter )
+inline void bursty_pipeline< T >::run( bursty_reader< T >& reader, const ::tbb::filter< T, void >& filter )
 {
     ::tbb::parallel_pipeline( number_of_threads_, reader.filter() & filter );
 }

--- a/imaging/cv_mat/detail/accumulated.cpp
+++ b/imaging/cv_mat/detail/accumulated.cpp
@@ -33,7 +33,7 @@
 #include <vector>
 #include <functional>
 #include <boost/date_time/posix_time/ptime.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <tbb/parallel_for.h>
 #include <tbb/blocked_range.h>
 #include "../depth_traits.h"
@@ -71,7 +71,7 @@ template< typename H, int DepthIn >
 static void divide_by_rows( const cv::Mat& m, cv::Mat& result, const apply_function& fn, comma::uint64 count )
 {
     tbb::parallel_for( tbb::blocked_range< std::size_t >( 0, m.rows ), 
-                       boost::bind( &iterate_pixels< DepthIn >, _1, m, boost::ref( result ), boost::ref(fn), count ) );
+                       boost::bind( &iterate_pixels< DepthIn >, boost::placeholders::_1, m, boost::ref( result ), boost::ref(fn), count ) );
 }
 
 template< typename H >

--- a/imaging/cv_mat/detail/bitwise.cpp
+++ b/imaging/cv_mat/detail/bitwise.cpp
@@ -29,7 +29,6 @@
 
 #include "bitwise.h"
 
-#include <boost/regex.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/algorithm/string/erase.hpp>
 #include <boost/algorithm/string/replace.hpp>

--- a/imaging/cv_mat/detail/ratio.h
+++ b/imaging/cv_mat/detail/ratio.h
@@ -38,7 +38,7 @@
 #include <boost/spirit/include/phoenix_operator.hpp>
 #include <boost/spirit/include/phoenix_object.hpp>
 #include <boost/spirit/include/phoenix.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 namespace snark{ namespace cv_mat {
 

--- a/imaging/cv_mat/detail/utils.cpp
+++ b/imaging/cv_mat/detail/utils.cpp
@@ -110,7 +110,7 @@ boost::unordered_map< std::string, unsigned int > fill_cvt_color_types_()
 {
     boost::unordered_map<std::string, unsigned int> types;
     //note RGB is exactly the same as BGR
-    types[ "CV_BGR2GRAY" ] = types[ "BGR,GRAY" ] = types[ "CV_RGB2GRAY" ] = types[ "RGB,GRAY" ] = CV_BGR2GRAY;
+    types[ "CV_BGR2GRAY" ] = types[ "BGR,GRAY" ] = types[ "cv::COLOR_RGB2GRAY" ] = types[ "RGB,GRAY" ] = CV_BGR2GRAY;
     types[ "CV_GRAY2BGR" ] = types[ "GRAY,BGR" ] = types[ "CV_GRAY2RGB" ] = types[ "GRAY,RGB" ] = CV_GRAY2BGR;
     types[ "CV_BGR2XYZ" ] = types[ "BGR,XYZ" ] = types[ "CV_RGB2XYZ" ] = types[ "RGB,XYZ" ] = CV_BGR2XYZ;
     types[ "CV_XYZ2BGR" ] = types[ "XYZ,BGR" ] = types[ "CV_XYZ2RGB" ] = types[ "XYZ,RGB" ] = CV_XYZ2BGR;
@@ -171,7 +171,7 @@ std::string make_filename( const boost::posix_time::ptime& t, const std::string&
 std::vector< int > imwrite_params( const std::string& type, const int quality )
 {
     std::vector< int > params;
-    if ( type == "jpg" ) { params.push_back( CV_IMWRITE_JPEG_QUALITY ); }
+    if ( type == "jpg" ) { params.push_back( cv::IMWRITE_JPEG_QUALITY ); }
     else { COMMA_THROW( comma::exception, "quality only supported for jpg images, not for \"" << type << "\" yet" ); }
     params.push_back( quality );
     return params;

--- a/imaging/cv_mat/pipeline.cpp
+++ b/imaging/cv_mat/pipeline.cpp
@@ -27,8 +27,7 @@
 // OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 // IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <boost/bind.hpp>
-#include <tbb/tbb_thread.h>
+#include <boost/bind/bind.hpp>
 #include <comma/base/last_error.h>
 #include "pipeline.h"
 
@@ -112,24 +111,24 @@ void pipeline< H >::setup_pipeline_()
 {
     if( m_filters.empty() )
     {
-        m_filter = ::tbb::filter_t< pair, void >( ::tbb::filter::serial_in_order, boost::bind( &pipeline< H >::write_, this, _1 ) );
+        m_filter = ::tbb::filter< pair, void >( ::tbb::filter_mode::serial_in_order, boost::bind( &pipeline< H >::write_, this, boost::placeholders::_1 ) );
     }
     else
     {
-        ::tbb::filter_t< pair, pair > all_filters;
+        ::tbb::filter< pair, pair > all_filters;
         bool has_null = false;
         for( std::size_t i = 0; i < m_filters.size(); ++i )
         {
-            ::tbb::filter::mode mode = ::tbb::filter::serial_in_order;
+            ::tbb::filter_mode mode = ::tbb::filter_mode::serial_in_order;
             if( m_filters[i].parallel )
             {
-                mode = ::tbb::filter::parallel;
+                mode = ::tbb::filter_mode::parallel;
             }
             if( !m_filters[i].filter_function ) { has_null = true; break; }
-            ::tbb::filter_t< pair, pair > filter( mode, boost::bind( m_filters[i].filter_function, _1 ) );
+            ::tbb::filter< pair, pair > filter( mode, boost::bind( m_filters[i].filter_function, boost::placeholders::_1 ) );
             all_filters = i == 0 ? filter : ( all_filters & filter );
         }
-        m_filter = all_filters & ::tbb::filter_t< pair, void >( ::tbb::filter::serial_in_order, boost::bind( has_null ? &pipeline< H >::null_ : &pipeline< H >::write_, this, _1 ) );
+        m_filter = all_filters & ::tbb::filter< pair, void >( ::tbb::filter_mode::serial_in_order, boost::bind( has_null ? &pipeline< H >::null_ : &pipeline< H >::write_, this, boost::placeholders::_1 ) );
     }
 }
 

--- a/imaging/cv_mat/pipeline.h
+++ b/imaging/cv_mat/pipeline.h
@@ -91,7 +91,7 @@ class pipeline
         void setup_pipeline_();
 
         cv_mat::serialization& m_output;
-        ::tbb::filter_t< pair, void > m_filter;
+        ::tbb::filter< pair, void > m_filter;
         std::vector< filter_type > m_filters;
         tbb::bursty_reader< pair >& m_reader;
         tbb::bursty_pipeline< pair > m_pipeline;

--- a/imaging/examples/regionprops-demo.cpp
+++ b/imaging/examples/regionprops-demo.cpp
@@ -44,7 +44,7 @@ int main( int ac, char** av )
     }
     cv::Mat image = cv::imread( av[1], 1 );
     cv::Mat binary;
-    cv::threshold( image, binary, 128, 255, CV_THRESH_BINARY_INV );
+    cv::threshold( image, binary, 128, 255, cv::THRESH_BINARY_INV );
     snark::imaging::region_properties properties( binary );
     properties.show( image );
     cv::imshow( "image", image );

--- a/imaging/frequency_domain.cpp
+++ b/imaging/frequency_domain.cpp
@@ -78,7 +78,7 @@ cv::Mat frequency_domain::filter( const cv::Mat& image, const cv::Mat& mask )
         cv::multiply( abs, paddedMaskF, abs );
     }
     cv::Mat result;
-    cv::normalize( abs, abs, 0, maxValue, CV_MINMAX ); // scale to get the same max value as the original TODO better scaling ?
+    cv::normalize( abs, abs, 0, maxValue, cv::NORM_MINMAX ); // scale to get the same max value as the original TODO better scaling ?
     abs.convertTo( result, CV_8U );
     return result;
 }
@@ -101,7 +101,7 @@ cv::Mat frequency_domain::magnitude() const
     shift( magnitudeImage );
     
  // transform the matrix with float values into a viewable image form (float between values 0 and 1).
-    cv::normalize( magnitudeImage, magnitudeImage, 0, 1, CV_MINMAX );
+    cv::normalize( magnitudeImage, magnitudeImage, 0, 1, cv::NORM_MINMAX );
     return magnitudeImage;
 }
 

--- a/imaging/region_properties.cpp
+++ b/imaging/region_properties.cpp
@@ -73,7 +73,7 @@ region_properties::region_properties ( const cv::Mat& image, double minArea ):
     cv::Mat binary;
     if( image.channels() == 3 )
     {
-        cv::cvtColor( image, binary, CV_RGB2GRAY );
+        cv::cvtColor( image, binary, cv::COLOR_RGB2GRAY );
     }
     else if( image.channels() == 1 )
     {
@@ -86,12 +86,12 @@ region_properties::region_properties ( const cv::Mat& image, double minArea ):
 //     cv::Mat closed;
 //     cv::morphologyEx( binary, closed, cv::MORPH_CLOSE, cv::Mat::ones( 3, 3, CV_8U) );
     std::vector< std::vector<cv::Point> > contours;
-    cv::findContours( binary, contours, CV_RETR_EXTERNAL, CV_CHAIN_APPROX_SIMPLE );
+    cv::findContours( binary, contours, cv::RETR_EXTERNAL, cv::CHAIN_APPROX_SIMPLE );
     
     for( unsigned int i = 0; i < contours.size(); i++ )
     {
         binary = cv::Scalar(0);
-        cv::drawContours( binary, contours, i, cv::Scalar(0xFF), CV_FILLED );
+        cv::drawContours( binary, contours, i, cv::Scalar(0xFF), cv::FILLED );
         cv::Rect rect = cv::boundingRect( cv::Mat( contours[i]) );
         cv::Moments moments = cv::moments( binary( rect ), true );
         double x = moments.m10/moments.m00;

--- a/imaging/vegetation/filters.cpp
+++ b/imaging/vegetation/filters.cpp
@@ -31,7 +31,7 @@
 #include <queue>
 #include <sstream>
 #include <boost/array.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/unordered_map.hpp>
@@ -137,14 +137,14 @@ static typename impl::filters< H >::value_type exponential_combination_impl_( co
 template < typename H >
 boost::function< typename impl::filters< H >::value_type( typename impl::filters< H >::value_type ) > impl::filters< H >::make_functor( const std::vector< std::string >& e )
 {
-    if( e[0] == "ndvi" ) { return boost::bind< value_type >( ndvi_impl_< H >, _1 ); }
+    if( e[0] == "ndvi" ) { return boost::bind< value_type >( ndvi_impl_< H >, boost::placeholders::_1 ); }
     if( e[0]=="exponential-combination" )
     {
         const std::vector< std::string >& s = comma::split( e[1], ',' );
         if( s[0].empty() ) { COMMA_THROW( comma::exception, "exponential-combination: expected powers got: \"" << e[1] << "\"" ); }
         std::vector< double > power( s.size() );
         for( unsigned int j = 0; j < s.size(); ++j ) { power[j] = boost::lexical_cast< double >( s[j] ); }
-        return boost::bind< value_type >( exponential_combination_impl_< H >, _1, power );
+        return boost::bind< value_type >( exponential_combination_impl_< H >, boost::placeholders::_1, power );
     }
     return NULL;
 }

--- a/math/gaussian_process/test/gaussian_process_test.cpp
+++ b/math/gaussian_process/test/gaussian_process_test.cpp
@@ -29,7 +29,7 @@
 
 
 #include <gtest/gtest.h>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <Eigen/Core>
 #include "../covariance.h"
 #include "../gaussian_process.h"
@@ -47,7 +47,7 @@ static void test_gaussian_process( const Eigen::MatrixXd& inputDomains
     snark::squared_exponential_covariance covariance( 1.0, 3.0, 0.1 );
     snark::gaussian_process gp( inputDomains
                                      , inputTargets
-                                     , boost::bind( &snark::squared_exponential_covariance::covariance, boost::ref( covariance ), _1, _2 )
+                                     , boost::bind( &snark::squared_exponential_covariance::covariance, boost::ref( covariance ), boost::placeholders::_1, _2 )
                                      , covariance.self_covariance() );
     Eigen::VectorXd outputMeans;
     Eigen::VectorXd outputVariances;

--- a/point_cloud/applications/points-foreground-partitions.cpp
+++ b/point_cloud/applications/points-foreground-partitions.cpp
@@ -41,8 +41,7 @@
 #include <map>
 #include <sstream>
 #include <vector>
-#include <tbb/pipeline.h>
-#include <tbb/task_scheduler_init.h>
+#include <tbb/parallel_pipeline.h>
 #include <boost/array.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/scoped_ptr.hpp>
@@ -348,22 +347,22 @@ int main( int ac, char** av )
         verbose = options.exists( "--verbose,-v" );
         discard = options.exists( "--discard,-d" );
         output_all = options.exists( "--output-all" );
-        ::tbb::filter_t< block_t*, block_t* > partition_filter( ::tbb::filter::serial_in_order, &partition_ );
-        ::tbb::filter_t< block_t*, void > write_filter( ::tbb::filter::serial_in_order, &write_block_ );
+        ::tbb::filter< block_t*, block_t* > partition_filter( ::tbb::filter_mode::serial_in_order, &partition_ );
+        ::tbb::filter< block_t*, void > write_filter( ::tbb::filter_mode::serial_in_order, &write_block_ );
         #ifdef PROFILE
         ProfilerStart( "points-foreground-partitions.prof" ); {
         #endif
         if( discard )
         {
             bursty_reader.reset( new snark::tbb::bursty_reader< block_t* >( &read_block_bursty_ ) );
-            ::tbb::filter_t< void, void > filters = bursty_reader->filter() & partition_filter & write_filter;
+            ::tbb::filter< void, void > filters = bursty_reader->filter() & partition_filter & write_filter;
             ::tbb::parallel_pipeline( 3, filters ); // while( bursty_reader->wait() ) { ::tbb::parallel_pipeline( 3, filters ); }
             bursty_reader->join();
         }
         else
         {
-            ::tbb::filter_t< void, block_t* > read_filter( ::tbb::filter::serial_in_order, &read_block_ );
-            ::tbb::filter_t< void, void > filters = read_filter & partition_filter & write_filter;
+            ::tbb::filter< void, block_t* > read_filter( ::tbb::filter_mode::serial_in_order, &read_block_ );
+            ::tbb::filter< void, void > filters = read_filter & partition_filter & write_filter;
             ::tbb::parallel_pipeline( 3, filters );
         }
         #ifdef PROFILE

--- a/point_cloud/applications/points-join.cpp
+++ b/point_cloud/applications/points-join.cpp
@@ -36,7 +36,7 @@
 #include <iostream>
 #include <map>
 #include <boost/array.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/function.hpp>
 #include <boost/optional.hpp>
 #include <comma/application/command_line_options.h>

--- a/point_cloud/applications/points-rays.cpp
+++ b/point_cloud/applications/points-rays.cpp
@@ -38,7 +38,7 @@
 #include <cmath>
 #include <string.h>
 #include <fstream>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/optional.hpp>
 #include <tbb/parallel_for.h>
 #include <comma/application/command_line_options.h>
@@ -225,7 +225,7 @@ int main( int argc, char** argv )
                 if( records.empty() ) { break; }
                 if( verbose ) { std::cerr << "points-rays: block " << records[0].first.block << ": loaded " << records.size() << " points in a grid of size " << grid.size() << " voxels" << std::endl; }
                 if( verbose ) { std::cerr << "points-rays: block " << records[0].first.block << ": tracing..." << std::endl; }
-                tbb::parallel_for( tbb::blocked_range< std::size_t >( 0, records.size(), records.size() / 4 ), boost::bind( &trace_points, _1, boost::ref( records ), boost::cref( grid ), threshold ) );
+                tbb::parallel_for( tbb::blocked_range< std::size_t >( 0, records.size(), records.size() / 4 ), boost::bind( &trace_points, boost::placeholders::_1, boost::ref( records ), boost::cref( grid ), threshold ) );
                 if( verbose ) { std::cerr << "points-rays: block " << records[0].first.block << ": outputting..." << std::endl; }
                 for( std::size_t i = 0; i < records.size(); ++i )
                 {

--- a/sensors/cameras/basler/applications/basler-cat.cpp
+++ b/sensors/cameras/basler/applications/basler-cat.cpp
@@ -1297,7 +1297,7 @@ static bool run_chunk_pipeline( Pylon::CBaslerGigECamera& camera
                                         , boost::ref( camera )
                                         , boost::ref( grabber ))
                            , max_queue_size, max_queue_capacity ));
-    tbb::filter_t< chunk_pair_t, void > writer( tbb::filter::serial_in_order, boost::bind( &write, _1 ));
+    tbb::filter< chunk_pair_t, void > writer( tbb::filter_mode::serial_in_order, boost::bind( &write, boost::placeholders::_1 ));
     snark::tbb::bursty_pipeline< chunk_pair_t > pipeline;
     camera.AcquisitionStart();
     comma::verbose << "running in chunk mode..." << std::endl;

--- a/sensors/cameras/flycapture/applications/flycapture-multicam.cpp
+++ b/sensors/cameras/flycapture/applications/flycapture-multicam.cpp
@@ -27,10 +27,10 @@
 // OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 // IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/thread.hpp>
 #include <tbb/concurrent_queue.h>
-#include <tbb/pipeline.h>
+#include <tbb/parallel_pipeline.h>
 #include <tbb/task_scheduler_init.h>
 #include <comma/application/command_line_options.h>
 #include <comma/base/exception.h>

--- a/sensors/cameras/flycapture/attributes.cpp
+++ b/sensors/cameras/flycapture/attributes.cpp
@@ -33,7 +33,7 @@
 #include <boost/thread.hpp>
 #include <boost/assign.hpp>
 #include <boost/bimap.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <comma/base/exception.h>
 #include <comma/csv/stream.h>
 #include "flycapture.h"

--- a/sensors/cameras/flycapture/flycapture.cpp
+++ b/sensors/cameras/flycapture/flycapture.cpp
@@ -33,7 +33,7 @@
 #include <boost/thread.hpp>
 #include <boost/assign.hpp>
 #include <boost/bimap.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <comma/base/exception.h>
 #include <comma/csv/stream.h>
 #include <comma/string/string.h>

--- a/sensors/cameras/flycapture/helpers.cpp
+++ b/sensors/cameras/flycapture/helpers.cpp
@@ -33,7 +33,7 @@
 #include <boost/thread.hpp>
 #include <boost/assign.hpp>
 #include <boost/bimap.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <comma/base/exception.h>
 #include <comma/csv/stream.h>
 #include "flycapture.h"

--- a/sensors/cameras/gige/applications/gige-callback.cpp
+++ b/sensors/cameras/gige/applications/gige-callback.cpp
@@ -27,10 +27,10 @@
 // OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 // IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/thread.hpp>
 #include <tbb/concurrent_queue.h>
-#include <tbb/pipeline.h>
+#include <tbb/parallel_pipeline.h>
 #include <tbb/task_scheduler_init.h>
 #include <comma/application/command_line_options.h>
 #include <comma/application/signal_flag.h>
@@ -233,21 +233,21 @@ int main( int argc, char** argv )
         }       
         callback.reset( new snark::camera::gige::callback( gige, on_frame_ ) );
         tbb::task_scheduler_init init;
-        tbb::filter_t< void, Pair > read( tbb::filter::serial_in_order, boost::bind( read_, _1 ) );
-        tbb::filter_t< Pair, void > write( tbb::filter::serial_in_order, boost::bind( write_, boost::ref( *serialization), _1 ) );
-        tbb::filter_t< void, Pair > imageFilters = read;
+        tbb::filter< void, Pair > read( tbb::filter_mode::serial_in_order, boost::bind( read_, boost::placeholders::_1 ) );
+        tbb::filter< Pair, void > write( tbb::filter_mode::serial_in_order, boost::bind( write_, boost::ref( *serialization), boost::placeholders::_1 ) );
+        tbb::filter< void, Pair > imageFilters = read;
 
         if( !filters.empty() )
         {
             std::vector< snark::cv_mat::filter > cvMatFilters = snark::cv_mat::filters::make( filters );
             for( std::size_t i = 0; i < cvMatFilters.size(); ++i )
             {
-                tbb::filter::mode mode = tbb::filter::serial_in_order;
+                tbb::filter_mode mode = tbb::filter_mode::serial_in_order;
                 if( cvMatFilters[i].parallel )
                 {
-                    mode = tbb::filter::parallel;
+                    mode = tbb::filter_mode::parallel;
                 }
-                tbb::filter_t< Pair, Pair > filter( mode, boost::bind( cvMatFilters[i].filter_function, _1 ) );
+                tbb::filter< Pair, Pair > filter( mode, boost::bind( cvMatFilters[i].filter_function, boost::placeholders::_1 ) );
                 imageFilters = imageFilters & filter;
             }
         }

--- a/sensors/cameras/vimba/applications/vimba-cat.cpp
+++ b/sensors/cameras/vimba/applications/vimba-cat.cpp
@@ -27,7 +27,7 @@
 // OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 // IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <comma/application/signal_flag.h>
 #include <comma/application/verbose.h>
 #include <comma/base/exception.h>
@@ -384,7 +384,7 @@ int main( int argc, char** argv )
         int exit_code = 0;
         while( acquiring )
         {
-            camera.start_acquisition( boost::bind( &output_frame, _1, boost::ref( serialization ), boost::ref( camera ) ), num_frames );
+            camera.start_acquisition( boost::bind( &output_frame, boost::placeholders::_1, boost::ref( serialization ), boost::ref( camera ) ), num_frames );
             comma::signal_flag is_shutdown;
             long frames_delivered = 0;
             do {

--- a/sensors/cameras/vimba/camera.cpp
+++ b/sensors/cameras/vimba/camera.cpp
@@ -28,7 +28,7 @@
 // IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <sstream>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <comma/application/verbose.h>
 #include <comma/name_value/map.h>
 
@@ -63,11 +63,11 @@ camera::name_values camera::info() const
 {
     name_values name_value_pairs;
 
-    add_name_value( "id",            boost::bind( &AVT::VmbAPI::Camera::GetID,           boost::cref( *camera_ ), _1 ), name_value_pairs );
-    add_name_value( "name",          boost::bind( &AVT::VmbAPI::Camera::GetName,         boost::cref( *camera_ ), _1 ), name_value_pairs );
-    add_name_value( "model",         boost::bind( &AVT::VmbAPI::Camera::GetModel,        boost::cref( *camera_ ), _1 ), name_value_pairs );
-    add_name_value( "serial_number", boost::bind( &AVT::VmbAPI::Camera::GetSerialNumber, boost::cref( *camera_ ), _1 ), name_value_pairs );
-    add_name_value( "interface_id",  boost::bind( &AVT::VmbAPI::Camera::GetInterfaceID,  boost::cref( *camera_ ), _1 ), name_value_pairs );
+    add_name_value( "id",            boost::bind( &AVT::VmbAPI::Camera::GetID,           boost::cref( *camera_ ), boost::placeholders::_1 ), name_value_pairs );
+    add_name_value( "name",          boost::bind( &AVT::VmbAPI::Camera::GetName,         boost::cref( *camera_ ), boost::placeholders::_1 ), name_value_pairs );
+    add_name_value( "model",         boost::bind( &AVT::VmbAPI::Camera::GetModel,        boost::cref( *camera_ ), boost::placeholders::_1 ), name_value_pairs );
+    add_name_value( "serial_number", boost::bind( &AVT::VmbAPI::Camera::GetSerialNumber, boost::cref( *camera_ ), boost::placeholders::_1 ), name_value_pairs );
+    add_name_value( "interface_id",  boost::bind( &AVT::VmbAPI::Camera::GetInterfaceID,  boost::cref( *camera_ ), boost::placeholders::_1 ), name_value_pairs );
 
     return name_value_pairs;
 }


### PR DESCRIPTION
Some updates to libraries to make things work with Ubuntu 22.04 (jammy)

These are mostly namespace changes (e.g. boost::bind, opencv no longer use global constants)
boost::regex has been moved to std
TBB has changed its interface quite a lot

There is some work to be done on managing these changes with CMake flags if we want to keep backwards compatibility